### PR TITLE
Changes to allow SWAT to run on Linux

### DIFF
--- a/code/run_swat.R
+++ b/code/run_swat.R
@@ -24,13 +24,45 @@ setwd(paste0(getwd(), '/TxtInOut'))
 ## get path
 project_path = getwd()
 
-## function from swat
+## function from SWATplusR
 '%&&%' <- function(a, b) paste(a, b, sep = " ")
+'%//%' <- function(a, b) paste(a, b, sep = "/")
+
+
+## function from SWATplusR to get os
+get_os <- function() {
+  if (.Platform$OS.type == "windows") {
+    "win"
+  } else if (Sys.info()["sysname"] == "Darwin") {
+    #"mac"
+    stop("SWATplusR only supported for Windows and Linux")
+  } else if (.Platform$OS.type == "unix") {
+    "unix"
+  } else {
+    stop("Unknown OS")
+  }
+}
+
+os <- get_os()
 
 ## find swat executable
-swat_exe = 
-  system("find"%&&%project_path%&&%"-executable -type f",
-       intern = T)
+if(os == "win") {
+  swat_exe <- list.files(project_path) %>%
+    .[grepl(".exe$",.)]
+  
+} else if(os == "unix") {
+  swat_exe <- system("find"%&&%project_path%&&%"-executable -type f",
+                     intern = T) %>%
+    basename(.)
+}
+
+run_os <- function(exe, os) {
+  if(os == 'unix') exe <- '.'%//%exe
+  return(exe)
+}
+
+exe <- run_os(swat_exe, os)
 
 ## run swat
-system(swat_exe)
+system(exe)
+


### PR DESCRIPTION
Deleted `swat670_static.exe`. This code requires that only one executable be in the `project_path`. Otherwise, `swat_exe` is a list.

Added additional code needed to run exe on Linux. 